### PR TITLE
Suggestions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ $(GEN)/javascript: $(BIN)/protoc Makefile
 	@mkdir -p javascript/gen/protobufjs
 	javascript/node_modules/.bin/pbjs -t static-module -w es6 -o javascript/gen/protobufjs/protos_pb.js $(PB)/conformance/conformance.proto $(PB)/src/google/protobuf/any.proto $(PB)/src/google/protobuf/field_mask.proto $(PB)/src/google/protobuf/timestamp.proto $(PB)/src/google/protobuf/duration.proto $(PB)/src/google/protobuf/struct.proto $(PB)/src/google/protobuf/wrappers.proto $(PB)/src/google/protobuf/test_messages_proto3.proto $(PB)/src/google/protobuf/test_messages_proto2.proto
 	javascript/node_modules/.bin/pbts -o javascript/gen/protobufjs/protos_pb.d.ts javascript/gen/protobufjs/protos_pb.js
-	if [ $(shell uname -s) == "Darwin" ] ; then \
-	   sed -i '' 's/ implements IMessageSetCorrect {/ {/' javascript/gen/protobufjs/protos_pb.d.ts; \
-       sed -i '' 's/import \* as $$protobuf from \"protobufjs\/minimal\";/import $$protobuf from \"protobufjs\/minimal\.js\";/' javascript/gen/protobufjs/protos_pb.js; \
-    else \
-	   sed -i'' 's/ implements IMessageSetCorrect {/ {/' javascript/gen/protobufjs/protos_pb.d.ts; \
-       sed -i'' 's/import \* as $$protobuf from \"protobufjs\/minimal\";/import $$protobuf from \"protobufjs\/minimal\.js\";/' javascript/gen/protobufjs/protos_pb.js; \
-    fi; \
+	#if [ $(shell uname -s) == "Darwin" ] ; then \
+#	   sed -i '' 's/ implements IMessageSetCorrect {/ {/' javascript/gen/protobufjs/protos_pb.d.ts; \
+#       sed -i '' 's/import \* as $$protobuf from \"protobufjs\/minimal\";/import $$protobuf from \"protobufjs\/minimal\.js\";/' javascript/gen/protobufjs/protos_pb.js; \
+#    else \
+#	   sed -i'' 's/ implements IMessageSetCorrect {/ {/' javascript/gen/protobufjs/protos_pb.d.ts; \
+#       sed -i'' 's/import \* as $$protobuf from \"protobufjs\/minimal\";/import $$protobuf from \"protobufjs\/minimal\.js\";/' javascript/gen/protobufjs/protos_pb.js; \
+#    fi; \
 	mkdir -p javascript/dist/esm/gen/protobufjs/
 	mv javascript/gen/protobufjs/*.js javascript/dist/esm/gen/protobufjs/
 	@mkdir -p $(@D)

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -32,14 +32,36 @@ seems to run twice.
 ### ProtobufJS
 
 For ProtobufJS conformance tests, we use the same expected failure lists as Protobuf-ES does in its list for
-environments without `BigInt` support.  While ProtobufJS does claim to support `BigInt` 
+environments without `BigInt` support.  
+
+--- Related to above:
+The purpose of the failure list is to be able to run the conformance tests with a success status code, even 
+when there are known problems. This is used to catch regressions in an implementation. We can use the failure
+lists to show the list of failures.
+We should not run protobuf.js with the failure list of protobuf-es. 
+protobuf.js should have its own failure list.
+Looks like javascript/protobufjs/failing_tests_list.txt should be deleted.
+---
+
+
+While ProtobufJS does claim to support `BigInt` 
 by [simply installing](https://github.com/protobufjs/protobuf.js#compatibility) the `long` library alongside 
 ProtobufJS, it still does not seem to pass the `BigInt` related tests.  However, in the interest of fairness, we
 mark these as expected to fail as Protobuf-ES does.
 
+--- Related to above:
+I don't believe protobuf.js claims to support `BigInt`. They do support 64-bit integral values. Yes, we should 
+have long.js installed in the tests. 
+---
+
+
 We also mark the same TextFormat tests as expected failures.
 
 ## Results
+
+Looks like protobuf-es with BigInt is missing the one recommended failure it has. And without BigInt, it has 
+9 required failures. I don't think we can just ignore them here. We could just leave out conformance tests without
+BigInt support though.
 
 | library      | recommended failures             | required failures               | total         |
 |---------------------|------------------------:|-----------------------:|-------------------:|

--- a/javascript/protobufjs/conformance.ts
+++ b/javascript/protobufjs/conformance.ts
@@ -17,21 +17,10 @@ import { readSync, writeSync } from "fs";
 import * as protos from "../gen/protobufjs/protos_pb.js";
 import type { Writer } from "protobufjs";
 
-const Any = protos.google.protobuf.Any;
-const Struct = protos.google.protobuf.Struct;
-const Value = protos.google.protobuf.Value;
-const Int32Value = protos.google.protobuf.Int32Value;
-const FieldMask = protos.google.protobuf.FieldMask;
-const Duration = protos.google.protobuf.Duration;
-const Timestamp = protos.google.protobuf.Timestamp;
-const TestAllTypesProto2 =
-  protos.protobuf_test_messages.proto2.TestAllTypesProto2;
-const TestAllTypesProto3 =
-  protos.protobuf_test_messages.proto3.TestAllTypesProto3;
-
-const ConformanceRequest = protos.conformance.ConformanceRequest;
-const ConformanceResponse = protos.conformance.ConformanceResponse;
-const FailureSet = protos.conformance.FailureSet;
+const {Any, Struct, Value, Int32Value, FieldMask, Duration, Timestamp} = protos.google.protobuf;
+const {TestAllTypesProto2} = protos.protobuf_test_messages.proto2;
+const {TestAllTypesProto3} = protos.protobuf_test_messages.proto3;
+const {ConformanceRequest, ConformanceResponse, FailureSet} = protos.conformance;
 
 type MessageType =
   | protos.protobuf_test_messages.proto2.TestAllTypesProto2
@@ -43,17 +32,6 @@ type MessageType =
   | protos.google.protobuf.Int32Value
   | protos.google.protobuf.Any
   | protos.google.protobuf.Timestamp;
-
-type MessageTypeInter =
-  protos.protobuf_test_messages.proto2.TestAllTypesProto2 &
-    protos.protobuf_test_messages.proto3.TestAllTypesProto3 &
-    protos.google.protobuf.Struct &
-    protos.google.protobuf.Value &
-    protos.google.protobuf.FieldMask &
-    protos.google.protobuf.Duration &
-    protos.google.protobuf.Int32Value &
-    protos.google.protobuf.Any &
-    protos.google.protobuf.Timestamp;
 
 interface Registry {
   [s: string]:
@@ -153,13 +131,13 @@ function test(request: protos.conformance.ConformanceRequest): Result {
     switch (request.requestedOutputFormat) {
       case 1: // PROTOBUF
         return {
-          protobufPayload: payloadType.encode(payload as MessageTypeInter),
+          protobufPayload: payloadType.encode(payload as any),
         };
 
       case 2: // JSON:
         return {
           jsonPayload: JSON.stringify(
-            payloadType.toObject(payload as MessageTypeInter)
+            payloadType.toObject(payload as any)
           ),
         };
 


### PR DESCRIPTION
- We should call ProtobufJS by it's official name "protobuf.js" consistently.

- javascript/gen is a bit confusing. Maybe just generate into the respective directory of the implementation, javascript/protobufjs/gen/ and javascript/protobuf-es/gen/ ?

- Running `make` resulted in an error `javascript/node_modules/.bin/protoc-gen-es: program not found or is not executable`

- Do we seriously have to patch the code generated by protobuf.js to compile it? Looks like the `sed` for "import" does nothing.