### PR TITLE
Minor formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A repository which runs the protocol buffers
 <!--- RESULTS-START -->
 | Implementation                          | Language                | Required tests                        | Recommended tests                        | Standard plugin | 
 |-----------------------------------------|-------------------------|--------------------------------------:|-----------------------------------------:|----------------:|
-| [google-protobuf](impl/google-protobuf) | JavaScript              | 74%&nbsp;passing<br>(383&nbsp;failures) | 62%&nbsp;passing<br>(207&nbsp;failures) |             yes |
-| [Protobuf-ES](impl/protobuf-es)         | TypeScript & JavaScript | 100%&nbsp;passing<br>(0&nbsp;failures)     | 100%&nbsp;passing<br>(1&nbsp;failures)     |             yes |
-| [protobuf.js](impl/protobuf.js)         | JavaScript & TypeScript | 38%&nbsp;passing<br>(921&nbsp;failures)     | 14%&nbsp;passing<br>(466&nbsp;failures)     |              no |
-| [protoc-gen-ts](impl/protoc-gen-ts)     | TypeScript              | 27%&nbsp;passing<br>(1081&nbsp;failures)    | 33%&nbsp;passing<br>(361&nbsp;failures)    |             yes |
-| [ts-proto](impl/ts-proto)               | TypeScript              | 43%&nbsp;passing<br>(843&nbsp;failures)        | 4%&nbsp;passing<br>(520&nbsp;failures)        |             yes |
+| [google-protobuf](impl/google-protobuf) | JavaScript              | 74.1%&nbsp;passing<br>(383&nbsp;failures) | 61.7%&nbsp;passing<br>(207&nbsp;failures) |             yes |
+| [Protobuf-ES](impl/protobuf-es)         | TypeScript & JavaScript | 100.0%&nbsp;passing<br>(0&nbsp;failures)     | 99.8%&nbsp;passing<br>(1&nbsp;failures)     |             yes |
+| [protobuf.js](impl/protobuf.js)         | JavaScript & TypeScript | 37.6%&nbsp;passing<br>(921&nbsp;failures)     | 13.7%&nbsp;passing<br>(466&nbsp;failures)     |              no |
+| [protoc-gen-ts](impl/protoc-gen-ts)     | TypeScript              | 26.8%&nbsp;passing<br>(1081&nbsp;failures)    | 33.1%&nbsp;passing<br>(361&nbsp;failures)    |             yes |
+| [ts-proto](impl/ts-proto)               | TypeScript              | 42.9%&nbsp;passing<br>(843&nbsp;failures)        | 3.7%&nbsp;passing<br>(520&nbsp;failures)        |             yes |
 <!--- RESULTS-END -->
 
 Note: None of the libraries tested implement the text format so the results for those test runs are not shown.

--- a/report.js
+++ b/report.js
@@ -38,7 +38,7 @@ function required(failures, base) {
   const total = base.requiredFailures;
   const fails = failures.requiredFailures;
   const passed = total - fails;
-  const percentage = (passed / total * 100).toFixed(0);
+  const percentage = (passed / total * 100).toFixed(1);
   return `${percentage}%&nbsp;passing<br>(${fails}&nbsp;failures)`;
 }
 
@@ -46,7 +46,7 @@ function recommended(failures, base) {
   const total = base.recommendedFailures;
   const fails = failures.recommendedFailures;
   const passed = total - fails;
-  const percentage = (passed / total * 100).toFixed(0);
+  const percentage = (passed / total * 100).toFixed(1);
   return `${percentage}%&nbsp;passing<br>(${fails}&nbsp;failures)`;
 }
 


### PR DESCRIPTION
Made two minor tweaks:

- Alphabetized list of libraries
- Adding `passing` to the test results because it was a bit confusing (at least to me) whether the percentage represents the total tests passing or failing.