### PR TITLE
Update to Protobuf v25.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TMP   = .tmp
 BIN   = .tmp/bin
 UNAME_OS := $(shell uname -s)
 LICENSE_HEADER_YEAR_RANGE := 2023
-GOOGLE_PROTOBUF_VERSION = 25.0-rc2
+GOOGLE_PROTOBUF_VERSION = 25.0
 
 ifeq ($(UNAME_OS),Darwin)
 	PLATFORM := osx-x86_64


### PR DESCRIPTION
This updates the conformance tests to run against the v25.0 release of Protobuf.