### PR TITLE
Update to Protobuf 25.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TMP   = .tmp
 BIN   = .tmp/bin
 UNAME_OS := $(shell uname -s)
 LICENSE_HEADER_YEAR_RANGE := 2023-2024
-GOOGLE_PROTOBUF_VERSION = 25.1
+GOOGLE_PROTOBUF_VERSION = 25.2
 
 ifeq ($(UNAME_OS),Darwin)
 	PLATFORM := osx-x86_64

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MAKEFLAGS += --no-print-directory
 TMP   = .tmp
 BIN   = .tmp/bin
 UNAME_OS := $(shell uname -s)
-LICENSE_HEADER_YEAR_RANGE := 2023
+LICENSE_HEADER_YEAR_RANGE := 2023-2024
 GOOGLE_PROTOBUF_VERSION = 25.1
 
 ifeq ($(UNAME_OS),Darwin)

--- a/report.js
+++ b/report.js
@@ -1,4 +1,4 @@
-// Copyright 2023 Buf Technologies, Inc.
+// Copyright 2023-2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This updates to use the new v25.2 Protobuf release. In addition, it also makes a drive-by update of the license year.