### PR TITLE
Update to macos-12

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
             ./conformance_test_runner-${{ needs.get-protobuf.outputs.version }}-linux-x86_64.zip
 
   build-darwin_x86_64:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: get-protobuf
     steps:
       - name: Checkout


### PR DESCRIPTION
Github is removing the `macos-11` runner on Jun 28.

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

This updates the release script to `macos-12` since that is the lowest supported version.