### PR TITLE
Upgrade to macos-13 GH image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
             ./conformance_test_runner-${{ needs.get-protobuf.outputs.version }}-linux-x86_64.zip
 
   build-darwin_x86_64:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: get-protobuf
     steps:
       - name: Checkout


### PR DESCRIPTION
The macos-12 image for GH actions is [deprecated](https://github.com/actions/runner-images/issues/10721).

This updates our workflow to use the lowest supported image (`macos-13`).