### PR TITLE
Publish v30.0-rc1 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           path: ./protobuf.tar.gz
 
   build-linux_x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: get-protobuf
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |
@@ -129,7 +129,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=6.5.0 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |
@@ -129,7 +129,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=6.5.0 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |
@@ -129,7 +129,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner --toolchain_resolution_debug=@bazel_tools//tools/cpp:toolchain_type
+          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |
@@ -129,7 +129,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner --toolchain_resolution_debug=@bazel_tools//tools/cpp:toolchain_type
+          USE_BAZEL_VERSION=6.3.0 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |
@@ -129,7 +129,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++14" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,6 +125,7 @@ jobs:
           mv bazelisk-darwin-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
           chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
 
+
       - name: Build Binary
         run: |
           tar -xf protobuf.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=6.5.0 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |
@@ -129,7 +129,7 @@ jobs:
         run: |
           tar -xf protobuf.tar.gz
           cd ./protobuf-${{ needs.get-protobuf.outputs.version }}
-          USE_BAZEL_VERSION=6.5.0 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
+          USE_BAZEL_VERSION=7.1.2 BAZEL_CXXOPTS="-std=c++17" bazel build conformance:conformance_test_runner
 
       - name: Rename Binary
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,7 +125,6 @@ jobs:
           mv bazelisk-darwin-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
           chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
 
-
       - name: Build Binary
         run: |
           tar -xf protobuf.tar.gz

--- a/scripts/download-conformance-release.js
+++ b/scripts/download-conformance-release.js
@@ -18,7 +18,7 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import { unzipSync } from "fflate";
 
 // Version of the conformance test runner / upstream google-protobuf release
-const version = "29.3"; // 30.0-rc1
+const version = "29.3";
 const protoDirectory = new URL("../proto", import.meta.url).pathname;
 const runnerDirectory = new URL("../node_modules/.bin", import.meta.url)
   .pathname;

--- a/scripts/download-conformance-release.js
+++ b/scripts/download-conformance-release.js
@@ -18,7 +18,7 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import { unzipSync } from "fflate";
 
 // Version of the conformance test runner / upstream google-protobuf release
-const version = "29.3";
+const version = "29.3"; // 30.0-rc1
 const protoDirectory = new URL("../proto", import.meta.url).pathname;
 const runnerDirectory = new URL("../node_modules/.bin", import.meta.url)
   .pathname;


### PR DESCRIPTION
In addition to publishing the v30.0-rc1 release, this also makes necessary changes to the Github Action which builds the release. Namely:

* Upgrade to C++17
* Upgrade ubuntu image to latest
* Upgrade to Bazel v7