### PR TITLE
Update to Protobuf v31.0

### DIFF
--- a/scripts/download-conformance-release.js
+++ b/scripts/download-conformance-release.js
@@ -18,7 +18,7 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import { unzipSync } from "fflate";
 
 // Version of the conformance test runner / upstream google-protobuf release
-const version = "30.2"; // 31.0
+const version = "31.0";
 const protoDirectory = new URL("../proto", import.meta.url).pathname;
 const runnerDirectory = new URL("../node_modules/.bin", import.meta.url)
   .pathname;

--- a/scripts/download-conformance-release.js
+++ b/scripts/download-conformance-release.js
@@ -18,7 +18,7 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import { unzipSync } from "fflate";
 
 // Version of the conformance test runner / upstream google-protobuf release
-const version = "30.2";
+const version = "30.2"; // 31.0
 const protoDirectory = new URL("../proto", import.meta.url).pathname;
 const runnerDirectory = new URL("../node_modules/.bin", import.meta.url)
   .pathname;


### PR DESCRIPTION
This updates the repo to the new v31.0 release of the conformance runner.